### PR TITLE
Remove kivy-example from pip requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ kivy-deps.angle==0.3.2; sys_platform == 'win32'
 kivy-deps.glew==0.3.1; sys_platform == 'win32'
 kivy-deps.gstreamer==0.3.3; sys_platform == 'win32'
 kivy-deps.sdl2==0.4.5; sys_platform == 'win32'
-Kivy-examples==2.0.0
 Kivy-Garden==0.1.4
 kivy-garden.filebrowser==1.1.2
 kivymd==0.104.2


### PR DESCRIPTION
Fix #4 